### PR TITLE
Fix missing glob passthrough

### DIFF
--- a/src/pylivestream/__main__.py
+++ b/src/pylivestream/__main__.py
@@ -143,6 +143,7 @@ def glob_run():
         timeout=P.timeout,
         loop=P.loop,
         video_path=P.path,
+        glob=P.glob,
         shuffle=P.shuffle,
         still_image=P.image,
         no_meta=P.nometa,


### PR DESCRIPTION
Found this project today and wanted to give it a shot - tried figuring out why my glob command wouldn't work, and found this issue. It appears this bug has been introduced lately.

I'm not familiar with Python and its ecosystem. Should I bump the version in `setup.cfg` to `1.11.1`?