### PR TITLE
Playlist

### DIFF
--- a/src/pylivestream/__main__.py
+++ b/src/pylivestream/__main__.py
@@ -148,3 +148,35 @@ def glob_run():
         still_image=P.image,
         no_meta=P.nometa,
     )
+
+def playlist():
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    p = ArgumentParser(description="Livestream a globbed input file list")
+    p.add_argument("path", help="path to discover files from")
+    p.add_argument(
+        "websites",
+        help="site to stream, e.g. localhost youtube periscope facebook twitch",
+        nargs="+",
+    )
+    p.add_argument("-i", "--ini", help="*.ini file with stream parameters")
+    p.add_argument("-image", help="static image to display, for audio-only files.")
+    p.add_argument("-shuffle", help="shuffle the globbed file list", action="store_true")
+    p.add_argument("-loop", help="repeat the globbed file list endlessly", action="store_true")
+    p.add_argument("-y", "--yes", help="no confirmation dialog", action="store_true")
+    p.add_argument("-nometa", help="do not add metadata caption to video", action="store_false")
+    p.add_argument("-t", "--timeout", help="stop streaming after --timeout seconds", type=int)
+    P = p.parse_args()
+
+    stream_playlist(
+        ini_file=P.ini,
+        websites=P.websites,
+        assume_yes=P.yes,
+        timeout=P.timeout,
+        loop=P.loop,
+        video_path=P.path,
+        glob=P.glob,
+        shuffle=P.shuffle,
+        still_image=P.image,
+        no_meta=P.nometa,
+    )

--- a/src/pylivestream/api.py
+++ b/src/pylivestream/api.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .base import FileIn, Microphone, Screenshare, SaveDisk, Webcam
-from .glob import fileglob, playonce
+from .glob import fileglob, playmulti, playonce
 
 __all__ = [
     "stream_file",
@@ -77,6 +77,37 @@ def stream_files(
     else:
         playonce(flist, still_image, websites, ini_file, shuffle, usemeta, assume_yes)
 
+def stream_playlist(
+    ini_file: Path,
+    websites: list[str],
+    *,
+    video_path: Path,
+    glob: str = None,
+    assume_yes: bool = False,
+    loop: bool = None,
+    shuffle: bool = None,
+    still_image: Path = None,
+    no_meta: bool = None,
+    timeout: float = None,
+):
+    # %% file / glob wranging
+    flist = fileglob(video_path, glob)
+    
+    print("streaming these files. Be sure list is correct! \n")
+    print("\n".join(map(str, flist)))
+    print()
+
+    if assume_yes:
+        print("going live on", websites)
+    else:
+        input(f"Press Enter to go live on {websites}.    Or Ctrl C to abort.")
+
+    usemeta = no_meta
+
+    # if loop:
+    #     while True:
+    #         playmulti(flist, still_image, websites, ini_file, shuffle, usemeta, assume_yes)
+    playmulti(flist, still_image, websites, ini_file, shuffle, usemeta, assume_yes, loop)
 
 def stream_microphone(
     ini_file: Path,

--- a/src/pylivestream/api.py
+++ b/src/pylivestream/api.py
@@ -104,9 +104,6 @@ def stream_playlist(
 
     usemeta = no_meta
 
-    # if loop:
-    #     while True:
-    #         playmulti(flist, still_image, websites, ini_file, shuffle, usemeta, assume_yes)
     playmulti(flist, still_image, websites, ini_file, shuffle, usemeta, assume_yes, loop)
 
 def stream_microphone(

--- a/src/pylivestream/base.py
+++ b/src/pylivestream/base.py
@@ -35,6 +35,8 @@ class Livestream(Stream):
 
         cmd += self.loglevel
         cmd += self.yes
+        if self.loop:
+            cmd += ["-stream_loop", "-1"]
 
         #        cmd += self.timelimit  # terminate input after N seconds, IF specified
 

--- a/src/pylivestream/glob.py
+++ b/src/pylivestream/glob.py
@@ -40,6 +40,25 @@ def playonce(
 
         s.golive()
 
+def playmulti(
+    flist: list[Path],
+    image: Path,
+    sites: list[str],
+    inifn: Path,
+    shuffle: bool,
+    usemeta: bool,
+    yes: bool,
+    loop: bool
+):
+
+    if shuffle:
+        random.shuffle(flist)
+
+    f = "\n".join(map(str, flist))
+
+    s = FileIn(inifn, sites, infn=f, loop=loop, image=image, caption="", yes=yes)
+
+    s.golive()
 
 def fileglob(path: Path, glob: str) -> list[Path]:
 


### PR DESCRIPTION
This is a first approach at resolving the issue that plagues multiple file streaming with an online/offline constant transition since the stream is reinitialized for each file. With this approach we use both the playlist and stream_loop features of ffmpeg. What I couldn't adapt to this kind of approach were input file randomization and captions. I guess there could be a way for both of them to work if we could get back information from ffmmpeg execution, such as the current file that's being streamed so that in an asynchronous way we could reshuffle the playlist string.