### PR TITLE
Flip the order of the image check

### DIFF
--- a/src/pylivestream/stream.py
+++ b/src/pylivestream/stream.py
@@ -87,11 +87,11 @@ class Stream:
             self.fps = C.get("screencap_fps")
             self.origin: list[str] = C.get("screencap_origin", [1, 1])
             self.movingimage = self.staticimage = False
+        elif self.image:  # audio-only stream + background image
+            self.res = utils.get_resolution(self.image, self.probeexe)
+            self.fps = utils.get_framerate(self.infn, self.probeexe)
         elif self.vidsource == "file":  # streaming video from a file
             self.res = utils.get_resolution(self.infn, self.probeexe)
-            self.fps = utils.get_framerate(self.infn, self.probeexe)
-        elif self.vidsource is None and self.image:  # audio-only stream + background image
-            self.res = utils.get_resolution(self.image, self.probeexe)
             self.fps = utils.get_framerate(self.infn, self.probeexe)
         else:  # audio-only
             self.res = None


### PR DESCRIPTION
This allows for the stream to use the image resolution in the case that we are using an audio file with a background image.